### PR TITLE
Removed photo option and simplified \photo command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,16 @@ See the `example.tex` file for additional details.
 \title{New Directions in Machine-verifiable\\ Progress Credentials and Fully Automated and Transparent Admissions Process}
 \authors{Hein Meling}
 \department{ide}
-% Optional: if photo option used, specify name of photo in photos folder
-% \photo{cern}
+% Optional: specify path to photo
+% \photo{photos/cern}
 \thesistype{master}
 \specialization{cs}
 
 \begin{document}
 \uiscover{1}
+%
+% Insert thesis content here
+%
 \uisbackcover
 \end{document}
 ```
@@ -58,7 +61,6 @@ The following package options are currently supported:
 
 | Option  | Description                                                |
 |---------|------------------------------------------------------------|
-| `photo` | Use photo; department specific photos are used by default  |
 | `print` | Align logo placement with color box to facilitate printing |
 
 ### Package Commands
@@ -72,7 +74,7 @@ The package supports the following commands:
 | `\department`     | Lower case department abbreviations, e.g., `ide` and `imbm`       |
 | `\thesistype`     | Supported: `bachelor`, `master`, and `phd`                        |
 | `\specialization` | Currently, only `cs, ds, ee, med` are supported; more to be added |
-| `\photo`          | Specifies name of photo in photos folder                          |
+| `\photo`          | Optional: Specify path to photo on cover page                     |
 | `\photocredit`    | Cover page photographer may be required                           |
 | `\uiscover`       | Display cover page, values 1-9 provide different color schemes    |
 | `\uisbackcover`   | Display back cover using the same color schemes as front cover    |
@@ -85,10 +87,7 @@ However, you can use both if you prefer.
 
 ### Photo on Cover Page
 
-- If you specify the `photo` package option, the default is to use a department specific photo.
-  For example, for `ide` a photo named `photos/ide` will be used.
-
-- If you want to use your own photo, for example a photo of your system, simply place the photo in the `photos` folder and specify the photo name using the `\photo` command.
+- If you want to use your own photo, for example a photo or screenshot of your system, simply specify the path to the photo using the `\photo` command.
   The usual image file types are supported.
 
 - You must credit the photographer if you use a photo that you didn't shoot yourself.
@@ -96,8 +95,7 @@ However, you can use both if you prefer.
 **Example:** Cover page with a photo placed in `photos/cern`.
 
 ```latex
-\usepackage[photo]{uis-thesis}
-\photo{cern}
+\photo{photos/cern}
 \photocredit{Ansel Adams}
 ```
 
@@ -125,8 +123,6 @@ For Ubuntu, see this thread on [askubuntu.com](https://askubuntu.com/questions/4
 
 - Need to find free replacement fonts for Overleaf; the one used on Linux is free.
 
-- Default photos are missing from the repository; I hope to add relevant photos soon
-
 ## Thanks and Contributions
 
 - LaTeX implementation by Hein Meling, December 2021 - January 2022
@@ -136,3 +132,5 @@ For Ubuntu, see this thread on [askubuntu.com](https://askubuntu.com/questions/4
 - Thanks to Susanna King for help and guidance with preparing this template
 
 - Thanks to Rodrigo Saramago for testing on Linux and providing font instructions
+
+- Thanks to Martin Gilje Jaatun for feedback.

--- a/example.tex
+++ b/example.tex
@@ -1,6 +1,6 @@
 \documentclass[12pt]{report}
 \usepackage[english]{babel}
-\usepackage[photo]{uis-thesis} % Options: print, photo
+\usepackage{uis-thesis} % Options: print
 
 % UiS recommends Georgia for the body text, but you are free to use another
 % font for the body text; if you want to use another font just remove this line.
@@ -9,8 +9,8 @@
 \title{New Directions in Machine-verifiable\\ Progress Credentials and Fully Automated and Transparent Admissions Process}
 \authors{Hein Meling}
 \department{ide}
-% Optional: if photo option used, specify name of photo in photos folder
-% \photo{cern}
+% Optional: specify path to photo
+\photo{photos/ide}
 % Optional: credit the photographer; required for many photos; you must check
 % \photocredit{Hein Meling}
 % Optional: uncomment if you want to display faculty name as well

--- a/test-uis-thesis.tex
+++ b/test-uis-thesis.tex
@@ -1,9 +1,7 @@
 \documentclass[12pt]{report}
 \usepackage[english]{babel}
-\usepackage[photo]{uis-thesis}
+\usepackage{uis-thesis}
 % \usepackage[print]{uis-thesis}
-% \usepackage[photo,print]{uis-thesis}
-% \usepackage[]{uis-thesis}
 
 % UiS recommends Georgia for the body text, but you are free to use another
 % font for the body text; if you want to use another font just remove this line.
@@ -11,7 +9,6 @@
 
 \title{Development of a miniaturized multi-Needle Langmuir Probe system for in-situ measurements of electrons density and spacecraft floating potential}
 \authors{Hein Meling}
-% \photo{ide}
 % Optional: uncomment if you want to display faculty name as well
 % \faculty{tn}
 % Allowed values: bachelor, master, phd
@@ -48,6 +45,7 @@
 \thesistype{bachelor}
 \specialization{ee}
 \department{ide}
+\photo{photos/ide}
 \uiscover{1}
 \department{imf}
 \uiscover{2}
@@ -58,6 +56,7 @@
 \department{iep}
 \specialization{ds}
 \uiscover{5}
+\selectlanguage{norsk}
 \department{ier}
 \specialization{ee}
 \uiscover{6}

--- a/uis-thesis.sty
+++ b/uis-thesis.sty
@@ -36,9 +36,7 @@
 \newfontfamily\authorfont{Tahoma Bold}
 \newfontfamily\titlefont[Scale=1.5]{Tahoma Bold}
 
-\newif\if@withphoto\@withphotofalse
 \newif\if@printlogo\@printlogofalse
-\DeclareOption{photo}{\@withphototrue}
 \DeclareOption{print}{\@printlogotrue}
 \DeclareOption*{\PackageWarning{uis-thesis}{Unknown ‘\CurrentOption’}}
 \ProcessOptions\relax
@@ -82,9 +80,9 @@
 \def\uis@e{} % empty box to avoid blank space
 \def\uis@logofile{\ifcurrentbaselanguage{Norsk}{logo/uis-logo-no-digital}{logo/uis-logo-en-digital}}
 
-% Use 'ide.jpg' as the default photo if \department or \photo not provided
-\def\uis@photo{ide}
-\def\photo#1{\def\uis@photo{#1}}
+\newif\if@withphoto\@withphotofalse
+\def\uis@photo{}
+\def\photo#1{\@withphototrue\def\uis@photo{#1}}
 
 \def\uis@photocredit{}
 \def\photocredit#1{
@@ -111,16 +109,17 @@
 }\fi%
 }
 
-% Unless the 'photo' package option is specified, the bottom part of
-% the frontpage is set to an empty minipage due to the ~.
-\def\uis@bottompart{~}
-\if@withphoto
-  \def\uis@bottompart{
-  \hspace*{-2.9mm}
-  \vspace*{-3mm}
-  \ClipImage{1.017\textwidth}{1.03\bottomheight}{photos/\uis@photo}
-  }
-\fi
+% Unless the \photo path is specified, the bottom part of the cover page
+% is set to an empty minipage due to the ~ in the else part.
+\def\uis@bottompart{%
+\if@withphoto{%
+    \hspace*{-2.2mm}%
+    \vspace*{-3mm}%
+    \ClipImage{1.017\textwidth}{1.03\bottomheight}{\uis@photo}%
+}%
+\else{~}%
+\fi%
+}
 
 \def\uis@authors{}
 \def\authors#1{\def\uis@authors{{\authorfont #1}}}
@@ -141,7 +140,6 @@
 \def\department#1{
   \IfTranslation{\languagename}{#1}{
     \def\uis@department{{\mainfont \GetTranslation{#1}}}
-    \ifx\uis@photo#1\else\photo{#1}\fi
   }{
     \PackageError{uis-thesis}{Unknown thesis type ‘#1’}{Legal departments: ide, imf, imbm, ikbm, ier, iep, isøp}
   }


### PR DESCRIPTION
The photo option is no longer supported and will not try to use department specific images.
Instead the author must specify a photo using \photo command, if a photo is wanted.
There is no longer a need to specify a photo option to the package.

Fixes #10, Closes #5.

