### PR TITLE
Renamed \thesistype to \reporttype

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ See the `example.tex` file for additional details.
 \department{ide}
 % Optional: specify path to photo
 % \photo{photos/cern}
-\thesistype{master}
+\reporttype{master}
 \specialization{cs}
 
 \begin{document}
@@ -72,7 +72,7 @@ The package supports the following commands:
 | `\title`          | May use `\\` to force line breaks                                 |
 | `\authors`        | Multiple authors should be separate with `,` and `and`            |
 | `\department`     | Lower case department abbreviations, e.g., `ide` and `imbm`       |
-| `\thesistype`     | Supported: `bachelor`, `master`, and `phd`                        |
+| `\reporttype`     | Supported: `bachelor`, `master`, and `phd`                        |
 | `\specialization` | Currently, only `cs, ds, ee, med` are supported; more to be added |
 | `\photo`          | Optional: Specify path to photo on cover page                     |
 | `\photocredit`    | Cover page photographer may be required                           |

--- a/example.tex
+++ b/example.tex
@@ -12,11 +12,11 @@
 % Optional: specify path to photo
 \photo{photos/ide}
 % Optional: credit the photographer; required for many photos; you must check
-% \photocredit{Hein Meling}
+\photocredit{Hein Meling}
 % Optional: uncomment if you want to display faculty name as well
 % \faculty{tn}
 % Allowed values: bachelor, master, phd
-\thesistype{master}
+\reporttype{master}
 % Allowed values: cs, ds, ee, medtek
 \specialization{cs}
 % Use only for phd thesis

--- a/test-uis-thesis.tex
+++ b/test-uis-thesis.tex
@@ -12,7 +12,7 @@
 % Optional: uncomment if you want to display faculty name as well
 % \faculty{tn}
 % Allowed values: bachelor, master, phd
-\thesistype{master}
+\reporttype{master}
 % Allowed values: cs, ds, ee, med
 \specialization{cs}
 % Uncomment only if your thesis has been granted restricted access
@@ -42,7 +42,7 @@
 \uiscover{9}
 
 \selectlanguage{nynorsk}
-\thesistype{bachelor}
+\reporttype{bachelor}
 \specialization{ee}
 \department{ide}
 \photo{photos/ide}

--- a/uis-thesis.sty
+++ b/uis-thesis.sty
@@ -148,10 +148,10 @@
 \def\uis@title{}
 \def\title#1{\def\uis@title{{\titlefont #1}}}
 
-\def\uis@thesistype{}
-\def\thesistype#1{
+\def\uis@reporttype{}
+\def\reporttype#1{
   \IfTranslation{\languagename}{#1}{
-    \def\uis@thesistype{{\mainfont \GetTranslation{#1}}}
+    \def\uis@reporttype{{\mainfont \GetTranslation{#1}}}
   }{
     \PackageError{uis-thesis}{Unknown thesis type ‘#1’}{Legal thesis types: bachelor, master, phd}
   }
@@ -205,7 +205,7 @@ January\or February\or March\or April\or May \or June\or July\or August\or Septe
 \vspace*{-2mm}
 \rule{\textwidth}{1pt}\par
 \vspace*{1mm}
-\uis@thesistype{} - \uis@specialization{} - \uis@date{} \hfill \uis@restricted
+\uis@reporttype{} - \uis@specialization{} - \uis@date{} \hfill \uis@restricted
 \end{minipage}
 }
 


### PR DESCRIPTION
In case someone wants to use the template for technical reports in the future.

Fixes #11

