### PR TITLE
Fixes PhD report line to include thesis no.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The package supports the following commands:
 | `\title`          | May use `\\` to force line breaks                                 |
 | `\authors`        | Multiple authors should be separate with `,` and `and`            |
 | `\department`     | Lower case department abbreviations, e.g., `ide` and `imbm`       |
-| `\reporttype`     | Supported: `bachelor`, `master`, and `phd`                        |
+| `\reporttype`     | Supported: `bachelor`, `master`, `phd`, and `tr`                  |
 | `\specialization` | Currently, only `cs, ds, ee, med` are supported; more to be added |
 | `\photo`          | Optional: Specify path to photo on cover page                     |
 | `\photocredit`    | Cover page photographer may be required                           |
@@ -84,6 +84,20 @@ The package supports the following commands:
 _I recommend to use only one of `\department` or `\faculty` to keep the page clean._
 Typically, `bachelor` and `master` thesis types should use `\department`, while the `phd` type should use `\faculty`.
 However, you can use both if you prefer.
+
+Report types `phd` and `tr` _should_ specify the thesis/report number in square brackets as follows:
+
+```latex
+\reporttype[404]{phd}
+```
+
+PhD thesis and technical report types ignores the `\specialization{}` command, so it is not necessary.
+However, bachelor and master thesis reports must specify the specialization, as follows:
+
+```latex
+\reporttype{master}
+\specialization{cs}
+```
 
 ### Photo on Cover Page
 

--- a/example.tex
+++ b/example.tex
@@ -15,8 +15,9 @@
 \photocredit{Hein Meling}
 % Optional: uncomment if you want to display faculty name as well
 % \faculty{tn}
-% Allowed values: bachelor, master, phd
+% Allowed values: bachelor, master, phd, tr
 \reporttype{master}
+% \reporttype[404]{phd}
 % Allowed values: cs, ds, ee, medtek
 \specialization{cs}
 % Use only for phd thesis

--- a/test-uis-thesis.tex
+++ b/test-uis-thesis.tex
@@ -11,7 +11,7 @@
 \authors{Hein Meling}
 % Optional: uncomment if you want to display faculty name as well
 % \faculty{tn}
-% Allowed values: bachelor, master, phd
+% Allowed values: bachelor, master, phd, tr
 \reporttype{master}
 % Allowed values: cs, ds, ee, med
 \specialization{cs}

--- a/uis-thesis.sty
+++ b/uis-thesis.sty
@@ -141,20 +141,25 @@
   \IfTranslation{\languagename}{#1}{
     \def\uis@department{{\mainfont \GetTranslation{#1}}}
   }{
-    \PackageError{uis-thesis}{Unknown thesis type ‘#1’}{Legal departments: ide, imf, imbm, ikbm, ier, iep, isøp}
+    \PackageError{uis-thesis}{Unknown department ‘#1’}{Legal departments: ide, imf, imbm, ikbm, ier, iep, isøp}
   }
 }
 
 \def\uis@title{}
 \def\title#1{\def\uis@title{{\titlefont #1}}}
 
-\def\uis@reporttype{}
-\def\reporttype#1{
-  \IfTranslation{\languagename}{#1}{
-    \def\uis@reporttype{{\mainfont \GetTranslation{#1}}}
-  }{
-    \PackageError{uis-thesis}{Unknown thesis type ‘#1’}{Legal thesis types: bachelor, master, phd}
-  }
+\newcommand{\reporttype}[2][]{
+\IfTranslation{\languagename}{#2}{}{
+  \PackageError{uis-thesis}{Unknown report type ‘#2’}{Legal report types: bachelor, master, phd, tr}
+}
+\def\uis@reportnum{#1}
+\ifx\uis@reportnum\empty
+  % bachelor or master thesis should specify \specialization
+  \def\uis@reportline{{\mainfont \GetTranslation{#2} - \uis@specialization{} - \uis@date{} \hfill \uis@restricted}}
+\else
+  % phd thesis or tech reports have numbers and ignore \specialization
+  \def\uis@reportline{{\mainfont \GetTranslation{#2} UiS no.~\uis@reportnum{} - \uis@date{} \hfill \uis@restricted}}
+\fi
 }
 
 \def\uis@specialization{}
@@ -205,7 +210,7 @@ January\or February\or March\or April\or May \or June\or July\or August\or Septe
 \vspace*{-2mm}
 \rule{\textwidth}{1pt}\par
 \vspace*{1mm}
-\uis@reporttype{} - \uis@specialization{} - \uis@date{} \hfill \uis@restricted
+\uis@reportline{}
 \end{minipage}
 }
 
@@ -265,6 +270,9 @@ www.uis.no                           \par
 \DeclareTranslation{English}{isøp}{Department of Safety, Economics and Planning}
 \DeclareTranslation{Norsk}  {isøp}{Institutt for sikkerheit, økonomi og planlegging} %nynorsk?
 
+\DeclareTranslationFallback {tr}{Technical Report}
+\DeclareTranslation{English}{tr}{Technical Report}
+\DeclareTranslation{Norsk}  {tr}{Teknisk rapport}
 \DeclareTranslationFallback {bachelor}{Bachelor's Thesis}
 \DeclareTranslation{English}{bachelor}{Bachelor's Thesis}
 \DeclareTranslation{Nynorsk}{bachelor}{Bacheloroppgåve}


### PR DESCRIPTION
This adds an optional argument to the \reporttype command, where the report's number can be given for phd thesis and technical reports.

For bachelor and master thesis projects, there is no change, and these should still use \specialization.

Fixes #7.
