### PR TITLE
Remove useless \topskip0pt

### DIFF
--- a/frontmatter/quote.tex
+++ b/frontmatter/quote.tex
@@ -1,6 +1,5 @@
 %!TEX root = ../thesis.tex
 
-\topskip0pt
 \vspace*{\fill}
 
 % Now comes the "Funny Quote", written in italics

--- a/uis-thesis.sty
+++ b/uis-thesis.sty
@@ -424,7 +424,6 @@ www.uis.no                           \par
 }{}
 
 \newcommand{\declaration}{
-\topskip0pt
 \vspace*{\fill}
 % remove any \\ specified in \title
 \def\\{\relax\ifhmode\unskip\fi\space\ignorespaces}


### PR DESCRIPTION
This removes two instances of \topskip0pt, which caused 2-3 extra pages to be generated in odd places.

I don't recall why these were added, but removing them seems to resolve the problem without adding other problems.

Thanks to @FTHuld for reporting this (on another repo.)

