### PR TITLE
fix: a4paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The use of the image material in the `logo` folders is restricted as follows:
 See the `example.tex` file for additional details.
 
 ```latex
-\documentclass[11pt]{book}
+\documentclass[11pt, a4paper]{book}
 \usepackage[american]{babel}
 \usepackage{uis-thesis}
 

--- a/examples/example.tex
+++ b/examples/example.tex
@@ -1,4 +1,4 @@
-\documentclass[12pt]{report}
+\documentclass[12pt, a4paper]{report}
 \usepackage[english]{babel}
 \usepackage{uis-thesis} % Options: print
 

--- a/examples/test-uis-thesis.tex
+++ b/examples/test-uis-thesis.tex
@@ -1,4 +1,4 @@
-\documentclass[12pt]{report}
+\documentclass[12pt, a4paper]{report}
 \usepackage[english]{babel}
 \usepackage{uis-thesis}
 % \usepackage[print]{uis-thesis}

--- a/thesis.tex
+++ b/thesis.tex
@@ -1,6 +1,6 @@
 %!TEX TS-program = xelatex
 
-\documentclass[11pt,oneside]{book}
+\documentclass[11pt,oneside, a4paper]{book}
 \usepackage[english]{babel}
 \usepackage{uis-thesis}
 \usepackage{lipsum}           % remove this line when you removed all \lipsum commands


### PR DESCRIPTION
Change paper size from default to a4.
As outlined in https://texdoc.org/serve/geometry.pdf/0#subsection.6.1 , this could have been in a config file, but this seemed a bit excessive. The `\ExecuteOptions{a4paper}` command does not take affect in uis-thesis.sty, therefore papersize is just set in `\documentclass`.
`\newgeometry` does also not support setting paper size.