### PR TITLE
Add packages for hyperref and improved citations

### DIFF
--- a/thesis.tex
+++ b/thesis.tex
@@ -12,7 +12,6 @@
 \setmainfont{Georgia}
 
 \usepackage{hyperref} % include hyperref to enable citations, references and url to appear as clickable links
-\usepackage[authoryear]{natbib} % ensure a more consensed citation style
 
 %-----------------------------------------------------------------
 \title{New Directions in Machine-verifiable\\ Progress Credentials and Fully Automated and Transparent Admissions Process}
@@ -67,7 +66,7 @@
 
 % \label{Bibliography}
 % \lhead{\emph{Bibliography}}  % Change the left side page header to "Bibliography"
-% \bibliographystyle{unsrtnat}  % Use the "unsrtnat" BibTeX style for formatting the Bibliography
+% \bibliographystyle{apalike2}  % Use the "apalike2" BibTeX style for formatting the Bibliography
 % \bibliography{Bibliography}  % The references (bibliography) information are stored in the file named "Bibliography.bib"
 
 \uisbackcover

--- a/thesis.tex
+++ b/thesis.tex
@@ -12,6 +12,7 @@
 \setmainfont{Georgia}
 
 \usepackage{hyperref} % include hyperref to enable citations, references and url to appear as clickable links
+\usepackage[authoryear]{natbib} % ensure a more consensed citation style
 
 %-----------------------------------------------------------------
 \title{New Directions in Machine-verifiable\\ Progress Credentials and Fully Automated and Transparent Admissions Process}

--- a/thesis.tex
+++ b/thesis.tex
@@ -11,6 +11,8 @@
 % font for the body text; if you want to use another font just remove this line.
 \setmainfont{Georgia}
 
+\usepackage{hyperref} % include hyperref to enable citations, references and url to appear as clickable links
+
 %-----------------------------------------------------------------
 \title{New Directions in Machine-verifiable\\ Progress Credentials and Fully Automated and Transparent Admissions Process}
 \authors{Hein Meling}


### PR DESCRIPTION
Include the `hyperref` package to enable clickable links in citations and references.

Change default reference format from `unsrtnat` to `apalike2`.
`unsrtnat` results in citations like:
> [Baloochestani et al.(2022)Baloochestani, Jehl, and Meling]

With the `apalike2`, this becomes
> [Baloochestani et al., 2022] 

However, with apalike2, references are alphabetically ordered and do not appear in order of appearance.